### PR TITLE
Use 'Hello world' instead of identity for notify

### DIFF
--- a/app.py
+++ b/app.py
@@ -132,7 +132,7 @@ def send_notification():
     identity = request.form.get('identity')
     notification = service.notifications.create(
         identity=identity,
-        body='Hello ' + identity + '!'
+        body='Hello world!'
     )
 
     return jsonify(message="Notification created!")


### PR DESCRIPTION
We want to discourage users from using personal information as notify identities. Changed the starter app to send "Hello world" instead of "Hello <identity>"