### PR TITLE
Allow for generic token, registration, and send-notification routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv, find_dotenv
 from os.path import join, dirname
 from inflection import underscore
 
-# Convert keys to snake_case to conform with the python api definition contract
+# Convert keys to snake_case to conform with the twilio-python api definition contract
 def snake_case_keys(somedict):
     return dict(map(lambda (key, value): (underscore(key), value), somedict.items()))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==0.10.1
 fake-factory==0.5.3
 twilio==6.2.0a1
 python-dotenv==0.6.0
+inflection==0.3.1

--- a/static/notify/notify.js
+++ b/static/notify/notify.js
@@ -2,7 +2,8 @@ $(function() {
 
     $('#sendNotificationButton').on('click', function() {
         $.post('/send-notification', {
-           identity: $('#identityInput').val()
+           identity: $('#identityInput').val(),
+           body: "Hello, World!"
         }, function(response) {
             $('#identityInput').val('');
             $('#message').html(response.message);


### PR DESCRIPTION
See https://github.com/TwilioDevEd/sdk-starter-node/pull/19 for similar changes.

The `snake_case` conversion is implemented to ensure that developers who write their model objects based on the keys defined in the REST API as `CamelCase`, or `camelCase` or `snake_case` all convert gracefully when using the `twilio-python` library which expects keys to be `snake_case`.