### PR TITLE
Upgrade to Sync v0.6, use the default instance.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,6 @@ TWILIO_CHAT_SERVICE_SID=
 # Required for Notify
 TWILIO_NOTIFICATION_SERVICE_SID=
 
-# Required for Sync
-TWILIO_SYNC_SERVICE_SID=
+# Optional for Sync
+# By default, this app will use the default instance for your account (named "default").
+# TWILIO_SYNC_SERVICE_SID=

--- a/README.md
+++ b/README.md
@@ -40,18 +40,32 @@ make sure to save this information in a secure location, or possibly your `~/.ba
 
 ### Configure product-specific settings
 
-Depending on which demos you'd like to run, you'll need to configure a few more values in your
-`.env` file.
+Depending on which demos you'd like to run, you may need to configure a few more values in your `.env` file.
 
-| Config Value  | Product Demo | Description |
-| :-------------  |:------------- |:------------- |
-`TWILIO_CHAT_SERVICE_SID` | Chat | Like a database for your Chat data - [generate one in the console here](https://www.twilio.com/console/chat/services)
-`TWILIO_SYNC_SERVICE_SID` | Sync (Preview) | Like a database for your Sync data - [generate one in the console here](https://www.twilio.com/console/sync/services)
-`TWILIO_NOTIFICATION_SERVICE_SID` | Notify (Beta) | You will need to create a Notify service - [generate one here](https://www.twilio.com/console/notify/services)
+#### Configuring Twilio Sync
 
-### Configuring Notify
+Twilio Sync works out of the box, using default settings per account. Once you have your API keys configured, run the application (see below) and [open a browser](http://localhost:5000/sync)!
 
-You will need to create a Notify Service through the [Twilio Console](https://www.twilio.com/console/notify/services), and add at least one credential on the [Mobile Push Credential screen](https://www.twilio.com/console/notify/credentials) (such as Apple Push Notification Service or Firebase Cloud Messaging for Android) to send notifications using Notify.
+#### Configuring Twilio Chat
+
+In addition to the above, you'll need to [generate a Chat Service](https://www.twilio.com/console/chat/services) in the Twilio Console. Put the result in your `.env` file.
+
+| Config Value  | Where to get one. |
+| :------------- |:------------- |
+`TWILIO_CHAT_SERVICE_SID` | Generate one in the [Twilio Chat console](https://www.twilio.com/console/chat/services)
+
+With this in place, run the application (see below) and [open a browser](http://localhost:5000/chat)!
+
+#### Configuring Twilio Notify
+
+You will need to create a Notify Service and add at least one credential on the [Mobile Push Credential screen](https://www.twilio.com/console/notify/credentials) (such as Apple Push Notification Service or Firebase Cloud Messaging for Android) to send notifications using Notify.
+
+| Config Value   | Where to get one. |
+| :------------- |:------------- |
+`TWILIO_NOTIFICATION_SERVICE_SID` | Generate one in the [Notify Console](https://www.twilio.com/console/notify/services) and put this in your `.env` file.
+A Push Credential | Generate one with Apple or Google and [configure it as a Notify credential](https://www.twilio.com/console/notify/credentials).
+
+Once you've done that, run the application (see below) and [open a browser](http://localhost:5000/notify)!
 
 ## Run the sample application
 

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from twilio.jwt.access_token import AccessToken
 from twilio.jwt.access_token.grants import (
     SyncGrant,
     VideoGrant,
-    IpMessagingGrant
+    ChatGrant
 )
 from dotenv import load_dotenv, find_dotenv
 from os.path import join, dirname
@@ -76,7 +76,7 @@ def generateToken(identity):
     account_sid = os.environ['TWILIO_ACCOUNT_SID']
     api_key = os.environ['TWILIO_API_KEY']
     api_secret = os.environ['TWILIO_API_SECRET']
-    sync_service_sid = os.environ['TWILIO_SYNC_SERVICE_SID']
+    sync_service_sid = os.environ.get('TWILIO_SYNC_SERVICE_SID', 'default')
     chat_service_sid = os.environ['TWILIO_CHAT_SERVICE_SID']
 
     # Create access token with credentials
@@ -93,7 +93,7 @@ def generateToken(identity):
 
     # Create an Chat grant and add to token
     if chat_service_sid:
-        chat_grant = IpMessagingGrant(service_sid=chat_service_sid)
+        chat_grant = ChatGrant(service_sid=chat_service_sid)
         token.add_grant(chat_grant)
 
     # Return token info as JSON

--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ from inflection import underscore
 
 # Convert keys to snake_case to conform with the twilio-python api definition contract
 def snake_case_keys(somedict):
-    return dict(map(lambda (key, value): (underscore(key), value), somedict.items()))
+    return dict(map(lambda key, value: (underscore(key), value), somedict.items()))
 
 app = Flask(__name__)
 fake = Factory.create()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.10.1
 fake-factory==0.5.3
-twilio==6.2.0a1
+twilio==6.8.0
 python-dotenv==0.6.0
 inflection==0.3.1


### PR DESCRIPTION
This PR also (I think) fixes a syntax error (some difference among python versions?). Maybe needs a look-over from a Python person.