### PR TITLE
Chat example: Only send message if generalChannel is available

### DIFF
--- a/static/chat/index.js
+++ b/static/chat/index.js
@@ -98,7 +98,7 @@ $(function() {
     // Send a new message to the general channel
     var $input = $('#chat-input');
     $input.on('keydown', function(e) {
-        if (e.keyCode == 13) {
+        if (e.keyCode == 13 && generalChannel) {
             generalChannel.sendMessage($input.val())
             $input.val('');
         }


### PR DESCRIPTION
Ensure `generalChannel` is available before attempting to send a message to it